### PR TITLE
"Value needs to be a string" when handling numeric property names

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,16 @@ function isQuotedProperty(node) {
 	return node.type === 'Literal' && node.parent.type === 'Property' && node.parent.key === node;
 }
 
+function ensureString(value) {
+    if (Object.prototype.toString.call(value) !== '[object String]') {
+        return value.toString();
+    }
+
+    return value;
+}
+
 function isSafeToUnquote(node) {
-	var results = unquotedValidator(node.value);
+	var results = unquotedValidator(ensureString(node.value));
 
 	return results.needsQuotes === false;
 }

--- a/test.js
+++ b/test.js
@@ -54,7 +54,8 @@ mocha.describe('quote props plugin', function() {
 		// Given.
 		var codeStr = "var t = {\
 			'subject': subject,\
-			data: null\
+			data: null,\
+            777: true\
 		};";
 
 		// When.
@@ -63,7 +64,8 @@ mocha.describe('quote props plugin', function() {
 		// Then.
 		assert.equal(formattedCode, 'var t = {\n' +
 			'  subject: subject,\n' +
-			'  data: null\n' +
+			'  data: null,\n' +
+            '  777: true\n' +
 		'};');
 	});
 });


### PR DESCRIPTION
According to [the MDN docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types), numeric property names are valid in JavaScript. Thus, esformatter-quote-props does remove the quotes around them:

Before:

``` javascript
var choices = {
    '': true,
    '1': true,
    '0': true,
    '0777': true,
    'a_string': true,
    '0222a': true
};
```

After:

``` javascript
var choices = {
  '': true,
  1: true,
  0: true,
  0777: true,
  a_string: true,
  '0222a': true
};
```

However, esformatter-quote-props throws an error when it has to handle them itself. If I run esformatter again on the result, an error occurs:

``` bash
$ esformatter --plugins esformatter-quote-props
var choices = {0777: true};
^D
Value needs to be a string
```

The attached pull request fixes this bug by simply making sure that the object passed to `unquotedValidator` is always a string. The tests were also updated to trigger the bug (see first commit).

Please merge if you like!
